### PR TITLE
Init Whiteboard WPF

### DIFF
--- a/Whiteboard/App.xaml
+++ b/Whiteboard/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="Whiteboard.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Whiteboard"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/Whiteboard/App.xaml.cs
+++ b/Whiteboard/App.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Whiteboard
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+    }
+}

--- a/Whiteboard/AssemblyInfo.cs
+++ b/Whiteboard/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                     //(used if a resource is not found in the page,
+                                     // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                              //(used if a resource is not found in the page,
+                                              // app, or any theme specific resource dictionaries)
+)]

--- a/Whiteboard/Class1.cs
+++ b/Whiteboard/Class1.cs
@@ -1,8 +1,0 @@
-﻿using System;
-
-namespace Whiteboard
-{
-    public class Class1
-    {
-    }
-}

--- a/Whiteboard/MainWindow.xaml
+++ b/Whiteboard/MainWindow.xaml
@@ -1,0 +1,18 @@
+﻿<Window x:Class="Whiteboard.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Whiteboard"
+        mc:Ignorable="d"
+        Title="MainWindow" Height="450" Width="800">
+    <Canvas Name="MyCan" Background="#FF3C1831" Focusable="True" Margin="63,57,52,42" MouseDown="OnCanvasMouseButtonDown" MouseUp="OnCanvasMouseButtonUp" MouseMove="OnCanvasMouseMove">
+        <Canvas.RenderTransform>
+            <TransformGroup>
+                <ScaleTransform/>
+                <SkewTransform/>
+                <TranslateTransform/>
+            </TransformGroup>
+        </Canvas.RenderTransform>
+    </Canvas>
+</Window>

--- a/Whiteboard/MainWindow.xaml.cs
+++ b/Whiteboard/MainWindow.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Whiteboard
+{
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml
+    /// </summary>
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void OnCanvasMouseButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void OnCanvasMouseButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void OnCanvasMouseMove(object sender, MouseEventArgs e)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Whiteboard/Whiteboard.csproj
+++ b/Whiteboard/Whiteboard.csproj
@@ -1,7 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net5.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
 
 </Project>

--- a/meet.me.sln
+++ b/meet.me.sln
@@ -1,20 +1,23 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client", "Client\Client.csproj", "{575F3368-89C0-4815-9D9D-F7CBE4FA9E8A}"
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31624.102
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Client", "Client\Client.csproj", "{575F3368-89C0-4815-9D9D-F7CBE4FA9E8A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Server", "Server\Server.csproj", "{D492D62B-36C6-4809-8F6B-3A9116BB6F3D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Server", "Server\Server.csproj", "{D492D62B-36C6-4809-8F6B-3A9116BB6F3D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Content", "Content\Content.csproj", "{0670C59F-47AF-4158-A531-6542A89DB256}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Content", "Content\Content.csproj", "{0670C59F-47AF-4158-A531-6542A89DB256}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dashboard", "Dashboard\Dashboard.csproj", "{320CF9B2-60F6-4464-840F-D43CF31E98E4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dashboard", "Dashboard\Dashboard.csproj", "{320CF9B2-60F6-4464-840F-D43CF31E98E4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Whiteboard", "Whiteboard\Whiteboard.csproj", "{93444113-A822-4DC8-A5B8-186E09C83B06}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScreenSharing", "ScreenSharing\ScreenSharing.csproj", "{2728084B-9263-4038-BBFD-57DD02640EEC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScreenSharing", "ScreenSharing\ScreenSharing.csproj", "{2728084B-9263-4038-BBFD-57DD02640EEC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Networking", "Networking\Networking.csproj", "{76CA701F-4B8D-495D-83D6-9A91E5A6614D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Networking", "Networking\Networking.csproj", "{76CA701F-4B8D-495D-83D6-9A91E5A6614D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Testing", "Testing\Testing.csproj", "{B682A6CB-3C4A-4E13-8B58-1BFCB47A8FC2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testing", "Testing\Testing.csproj", "{B682A6CB-3C4A-4E13-8B58-1BFCB47A8FC2}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Whiteboard", "Whiteboard\Whiteboard.csproj", "{93AEDFF1-6654-4875-9635-BCAC8C0B8291}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -38,10 +41,6 @@ Global
 		{320CF9B2-60F6-4464-840F-D43CF31E98E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{320CF9B2-60F6-4464-840F-D43CF31E98E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{320CF9B2-60F6-4464-840F-D43CF31E98E4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{93444113-A822-4DC8-A5B8-186E09C83B06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{93444113-A822-4DC8-A5B8-186E09C83B06}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{93444113-A822-4DC8-A5B8-186E09C83B06}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{93444113-A822-4DC8-A5B8-186E09C83B06}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2728084B-9263-4038-BBFD-57DD02640EEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2728084B-9263-4038-BBFD-57DD02640EEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2728084B-9263-4038-BBFD-57DD02640EEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -54,5 +53,15 @@ Global
 		{B682A6CB-3C4A-4E13-8B58-1BFCB47A8FC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B682A6CB-3C4A-4E13-8B58-1BFCB47A8FC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B682A6CB-3C4A-4E13-8B58-1BFCB47A8FC2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93AEDFF1-6654-4875-9635-BCAC8C0B8291}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93AEDFF1-6654-4875-9635-BCAC8C0B8291}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93AEDFF1-6654-4875-9635-BCAC8C0B8291}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93AEDFF1-6654-4875-9635-BCAC8C0B8291}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E2E13AE3-45D7-4307-8869-62957AF9E423}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Initial Whiteboard project created through WPF template with .NET 5.0

The Whiteboard.csproj file contains `<TargetFramework>net5.0-windows</TargetFramework>`, contrary to originally `<TargetFramework>net5.0</TargetFramework>`.
This change is necessary to use all the `Windows` libraries like Media, Shape, Canvas etc, please confirm with main repo to avoid future confusion.